### PR TITLE
Updated unistd.h references to compile under Windows 10

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -1,8 +1,13 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#ifndef _WIN32
+#if defined(_WIN32) || defined(_WIN64)
+#include <io.h>
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
+#else
 #include <unistd.h>
+#define O_BINARY 0
 #endif
 #include "mstrings.h"
 #include "header.h"

--- a/rclink.c
+++ b/rclink.c
@@ -1,7 +1,14 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(_WIN32) || defined(_WIN64)
+#include <io.h>
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
+#else
 #include <unistd.h>
+#define O_BINARY 0
+#endif
 
 #define OUTPUT_COM 1
 #define OUTPUT_CMD 2


### PR DESCRIPTION
Updated include unistd.h references to compile under Windows 10 (_WIN64) as well as Win32.